### PR TITLE
fix: refresh attribution when style changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add attribution handling to the Leaflet layer based on the `attributionControl` option and the source's `attribution` property
 
+### Fixed
+
+- Ensure attribution updates when switching MapLibre styles
+
 ## 0.1.0
 
 ### Fixed - 2025-03-24

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ var gl = L.maplibreGL({
 }).addTo(map);
 ```
 
+When switching MapLibre styles, the plugin automatically synchronizes the active style's source attributions with Leaflet's attribution control.
+
 Once you have created the leaflet layer, the maplibre-gl map object can be accessed using
 
 ```javascript

--- a/leaflet-maplibre-gl.js
+++ b/leaflet-maplibre-gl.js
@@ -159,15 +159,26 @@
             this._glMap = new maplibregl.Map(options);
 
             var _map = this._map;
-            var _currentAttribution = this.getAttribution();
             var _getAttribution = this.getAttribution.bind(this);
-            this._glMap.on('load', function () {
-                // Force attribution update
+            var _currentAttribution = null;
+
+            var _updateAttribution = function () {
                 if (_map && _map.attributionControl) {
-                    _map.attributionControl.removeAttribution(_currentAttribution);
-                    _map.attributionControl.addAttribution(_getAttribution());
+                    var newAttr = _getAttribution();
+                    if (newAttr !== _currentAttribution) {
+                        if (_currentAttribution) {
+                            _map.attributionControl.removeAttribution(_currentAttribution);
+                        }
+                        if (newAttr) {
+                            _map.attributionControl.addAttribution(newAttr);
+                        }
+                        _currentAttribution = newAttr;
+                    }
                 }
-            });
+            };
+
+            this._glMap.on('load', _updateAttribution);
+            this._glMap.on('styledata', _updateAttribution);
 
             // allow GL base map to pan beyond min/max latitudes
             // Defensively check if properties are writable before setting them,


### PR DESCRIPTION
## Summary
- ensure Leaflet attribution updates when MapLibre style or sources change
- document attribution fix in changelog and README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8675a5d70832891c3d890a9640537