### PR TITLE
fix: refresh attribution when style changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add attribution handling to the Leaflet layer based on the `attributionControl` option and the source's `attribution` property
 
+### Fixed
+
+- Ensure Leaflet attribution refreshes after MapLibre styles or sources load
+
 ## 0.1.0
 
 ### Fixed - 2025-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-### Added
-
-- Add attribution handling to the Leaflet layer based on the `attributionControl` option and the source's `attribution` property
-
 ### Fixed
 
-- Ensure Leaflet attribution refreshes after MapLibre styles or sources load
+- Fix attribution not updating when MapLibre styles or sources change
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ var gl = L.maplibreGL({
 }).addTo(map);
 ```
 
+When switching MapLibre styles, the plugin automatically synchronizes the active style's source attributions with Leaflet's attribution control.
+
 Once you have created the leaflet layer, the maplibre-gl map object can be accessed using
 
 ```javascript

--- a/leaflet-maplibre-gl.js
+++ b/leaflet-maplibre-gl.js
@@ -159,13 +159,30 @@
             this._glMap = new maplibregl.Map(options);
 
             var _map = this._map;
-            var _currentAttribution = this.getAttribution();
             var _getAttribution = this.getAttribution.bind(this);
-            this._glMap.on('load', function () {
-                // Force attribution update
+            var _currentAttribution = null;
+
+            var _updateAttribution = function () {
                 if (_map && _map.attributionControl) {
-                    _map.attributionControl.removeAttribution(_currentAttribution);
-                    _map.attributionControl.addAttribution(_getAttribution());
+                    var newAttr = _getAttribution();
+                    if (newAttr !== _currentAttribution) {
+                        if (_currentAttribution) {
+                            _map.attributionControl.removeAttribution(_currentAttribution);
+                        }
+                        if (newAttr) {
+                            _map.attributionControl.addAttribution(newAttr);
+                        }
+                        _currentAttribution = newAttr;
+                    }
+                }
+            };
+
+            this._glMap.on('load', _updateAttribution);
+            this._glMap.on('styledata', _updateAttribution);
+            this._glMap.on('style.load', _updateAttribution);
+            this._glMap.on('sourcedata', function (e) {
+                if (e.sourceDataType === 'metadata' && e.isSourceLoaded) {
+                    _updateAttribution();
                 }
             });
 

--- a/leaflet-maplibre-gl.js
+++ b/leaflet-maplibre-gl.js
@@ -86,9 +86,10 @@
                     var attributions = Object.keys(style.sources)
                         .map(function (sourceId) {
                             var styleSource = style.sources[sourceId];
-                            return (styleSource && typeof styleSource.attribution === 'string')
-                                ? styleSource.attribution.trim()
-                                : null;
+                            if (styleSource && typeof styleSource.attribution === 'string') {
+                                return styleSource.attribution.trim();
+                            }
+                            return null;
                         })
                         .filter(Boolean); // Remove null/undefined values
 

--- a/leaflet-maplibre-gl.js
+++ b/leaflet-maplibre-gl.js
@@ -77,18 +77,22 @@
                 return this.options.attributionControl.customAttribution;
             }
 
-            // Gather attributions from MapLibre styles
+            // Gather attributions from MapLibre style sources
             var map = this._glMap;
             if (map && this.options.attributionControl !== false) {
                 var style = map.getStyle();
+
                 if (style && style.sources) {
-                    return Object.keys(style.sources)
+                    var attributions = Object.keys(style.sources)
                         .map(function (sourceId) {
-                            var source = map.getSource(sourceId);
-                            return (source && typeof source.attribution === 'string') ? source.attribution.trim() : null;
+                            var styleSource = style.sources[sourceId];
+                            return (styleSource && typeof styleSource.attribution === 'string')
+                                ? styleSource.attribution.trim()
+                                : null;
                         })
-                        .filter(Boolean) // Remove null/undefined values
-                        .join(', ');
+                        .filter(Boolean); // Remove null/undefined values
+
+                    return attributions.join(', ');
                 }
             }
 
@@ -165,6 +169,7 @@
             var _updateAttribution = function () {
                 if (_map && _map.attributionControl) {
                     var newAttr = _getAttribution();
+
                     if (newAttr !== _currentAttribution) {
                         if (_currentAttribution) {
                             _map.attributionControl.removeAttribution(_currentAttribution);
@@ -177,14 +182,9 @@
                 }
             };
 
-            this._glMap.on('load', _updateAttribution);
+            // Listen to styledata event - this fires when style changes
+            // including when switching between different styles
             this._glMap.on('styledata', _updateAttribution);
-            this._glMap.on('style.load', _updateAttribution);
-            this._glMap.on('sourcedata', function (e) {
-                if (e.sourceDataType === 'metadata' && e.isSourceLoaded) {
-                    _updateAttribution();
-                }
-            });
 
             // allow GL base map to pan beyond min/max latitudes
             // Defensively check if properties are writable before setting them,


### PR DESCRIPTION
This pull request addresses a bug with attribution handling in the Leaflet MapLibre GL plugin, ensuring that attributions are correctly updated when MapLibre styles or sources change. The changes improve how attributions are gathered and synchronized with Leaflet's attribution control, and update the documentation to reflect the new behavior.

**Bug fix and attribution synchronization:**

* Fixed the issue where attributions were not updating when MapLibre styles or sources changed, by listening to the `styledata` event and updating the attribution control accordingly (`leaflet-maplibre-gl.js`). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL9-R11) [[2]](diffhunk://#diff-1439e09ed95e59c35bdafeac4d23733a4ccb138eaee1bc7e023fee56276cee6bL162-R188)
* Improved the attribution gathering logic to pull attributions directly from the style's sources, ensuring more accurate and reliable attribution display (`leaflet-maplibre-gl.js`).

**Documentation update:**

* Updated the `README.md` to clarify that the plugin now automatically synchronizes source attributions with Leaflet's attribution control when switching MapLibre styles.

**Changelog update:**

* Updated the `CHANGELOG.md` to reflect the bug fix for attribution synchronization.